### PR TITLE
Fix switch converge and verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Ansible Role: Golang
 ====================
 
+[![CI](https://github.com/webdavis/ansible-role-golang/actions/workflows/ci.yml/badge.svg)](https://github.com/webdavis/ansible-role-golang/actions/workflows/ci.yml)
+
 An Ansible Role that installs the [Go programming language](https://golang.org/).
 
 Requirements

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-# Set golang_packages if you would like to use a different version than the default for the OS
-# (see defaults per operating system in the `vars` directory).
+# Set golang_packages if you would like to use a different version than the default for the OS.
+# (See defaults per operating system in the `vars` directory.)
 # golang_packages: []
 
 # To install a specific version of the Go programming language, set

--- a/molecule/default/binary_install.yml
+++ b/molecule/default/binary_install.yml
@@ -10,7 +10,7 @@
 
   pre_tasks:
     - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=true cache_valid_time={{ 60 * 15 }}"
+      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
       when: ansible_os_family == 'Debian'
       changed_when: false
 

--- a/molecule/default/binary_install_with_checksum.yml
+++ b/molecule/default/binary_install_with_checksum.yml
@@ -12,7 +12,7 @@
 
   pre_tasks:
     - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=true cache_valid_time={{ 60 * 15 }}"
+      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
       when: ansible_os_family == 'Debian'
       changed_when: false
 

--- a/molecule/default/binary_install_with_go_env_vars.yml
+++ b/molecule/default/binary_install_with_go_env_vars.yml
@@ -12,7 +12,7 @@
 
   pre_tasks:
     - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=true cache_valid_time={{ 60 * 15 }}"
+      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
       when: ansible_os_family == 'Debian'
       changed_when: false
 

--- a/molecule/default/binary_install_with_goroot_versioned.yml
+++ b/molecule/default/binary_install_with_goroot_versioned.yml
@@ -11,7 +11,7 @@
 
   pre_tasks:
     - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=true cache_valid_time={{ 60 * 15 }}"
+      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
       when: ansible_os_family == 'Debian'
       changed_when: false
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,7 @@
 
   pre_tasks:
     - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=true cache_valid_time={{ 60 * 15 }}"
+      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
       when: ansible_os_family == 'Debian'
       changed_when: false
 

--- a/molecule/default/package_install_with_go_env_vars.yml
+++ b/molecule/default/package_install_with_go_env_vars.yml
@@ -9,7 +9,7 @@
 
   pre_tasks:
     - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=true cache_valid_time={{ 60 * 15 }}"
+      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
       when: ansible_os_family == 'Debian'
       changed_when: false
 

--- a/molecule/force_update/converge.yml
+++ b/molecule/force_update/converge.yml
@@ -11,7 +11,7 @@
 
   pre_tasks:
     - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=true cache_valid_time={{ 60 * 15 }}"
+      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
       when: ansible_os_family == 'Debian'
       changed_when: false
 

--- a/molecule/force_update/converge.yml
+++ b/molecule/force_update/converge.yml
@@ -1,12 +1,48 @@
 ---
-- name: Verify
+- name: Converge
   hosts: all
   become: true
 
-  tasks:
+  vars:
+    golang_binary_install:
+      enable: true
+      version: 1.15.8
+    golang_goroot_versioned: true
+
+  pre_tasks:
+    - name: Update Apt Cache
+      ansible.builtin.apt: "update_cache=true cache_valid_time={{ 60 * 15 }}"
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+
+  roles:
+    - ansible-role-golang
+
+  post_tasks:
+    - name: Add file to GOROOT
+      ansible.builtin.lineinfile:
+        path: "{{ goroot }}/force_update_file"
+        line: foobar
+        create: yes
+
+- name: Force Update
+  hosts: all
+  become: true
+
+  vars:
+    golang_binary_install:
+      enable: true
+      version: 1.15.8
+    golang_goroot_versioned: true
+    golang_force_update: true
+
+  roles:
+    - ansible-role-golang
+
+  post_tasks:
     - name: Check if force_update_test_file Exists
       stat:
-        path: /usr/local/go/force_update_file"
+        path: "{{ goroot }}/force_update_file"
       register: force_update_file
 
     - name: Ensure the Update was Forced

--- a/molecule/force_update/verify.yml
+++ b/molecule/force_update/verify.yml
@@ -1,48 +1,12 @@
 ---
-- name: Converge
+- name: Verify
   hosts: all
   become: true
 
-  vars:
-    golang_binary_install:
-      enable: true
-      version: 1.15.8
-    golang_goroot_versioned: true
-
-  pre_tasks:
-    - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=true cache_valid_time={{ 60 * 15 }}"
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-
-  roles:
-    - ansible-role-golang
-
-  post_tasks:
-    - name: Add file to GOROOT
-      ansible.builtin.lineinfile:
-        path: "{{ goroot }}/force_update_file"
-        line: foobar
-        create: yes
-
-- name: Force Update
-  hosts: all
-  become: true
-
-  vars:
-    golang_binary_install:
-      enable: true
-      version: 1.15.8
-    golang_goroot_versioned: true
-    golang_force_update: true
-
-  roles:
-    - ansible-role-golang
-
-  post_tasks:
+  tasks:
     - name: Check if force_update_test_file Exists
       stat:
-        path: "{{ goroot }}/force_update_file"
+        path: /usr/local/go/force_update_file"
       register: force_update_file
 
     - name: Ensure the Update was Forced

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install Go
-  ansible.builtin.apt: "name={{ go_packages }} update_cache=true cache_valid_time={{ 60 * 15 }}"
+  ansible.builtin.apt: "name={{ go_packages }} update_cache=yes cache_valid_time={{ 60 * 15 }}"
   when: not golang_force_update
 
 - name: Install Latest Go
-  ansible.builtin.apt: "name={{ go_packages }} state=latest update_cache=true cache_valid_time={{ 60 * 15 }}"
+  ansible.builtin.apt: "name={{ go_packages }} state=latest update_cache=yes cache_valid_time={{ 60 * 15 }}"
   when: golang_force_update


### PR DESCRIPTION
This PR does the following:

- I accidentally mixed up the plays for `molecule/force_update/converge.yml` and `molecule/force_update/verify.yml`, so this swaps them.
- Updates the `ansible.builtin.apt` modules `update_cache=true` parameter to `update_cache=yes`.
- Adds a CI status badge to the `README.md`.
- Fixes some comment grammar in `defaults/main.yml`.