### PR TITLE
Remove apt update_cache pre_task from molecule plays

### DIFF
--- a/molecule/default/binary_install.yml
+++ b/molecule/default/binary_install.yml
@@ -8,11 +8,5 @@
       enable: true
       version: 1.15.8
 
-  pre_tasks:
-    - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-
   roles:
     - ansible-role-golang

--- a/molecule/default/binary_install_with_checksum.yml
+++ b/molecule/default/binary_install_with_checksum.yml
@@ -10,11 +10,5 @@
     golang_checksum:
       amd64: d3379c32a90fdf9382166f8f48034c459a8cc433730bc9476d39d9082c94583b
 
-  pre_tasks:
-    - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-
   roles:
     - ansible-role-golang

--- a/molecule/default/binary_install_with_go_env_vars.yml
+++ b/molecule/default/binary_install_with_go_env_vars.yml
@@ -10,11 +10,5 @@
     golang_goroot: true
     golang_gopath: /root/go
 
-  pre_tasks:
-    - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-
   roles:
     - ansible-role-golang

--- a/molecule/default/binary_install_with_goroot_versioned.yml
+++ b/molecule/default/binary_install_with_goroot_versioned.yml
@@ -9,11 +9,5 @@
       version: 1.15.8
     golang_goroot_versioned: true
 
-  pre_tasks:
-    - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-
   roles:
     - ansible-role-golang

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,11 +3,5 @@
   hosts: all
   become: true
 
-  pre_tasks:
-    - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-
   roles:
     - ansible-role-golang

--- a/molecule/default/package_install_with_go_env_vars.yml
+++ b/molecule/default/package_install_with_go_env_vars.yml
@@ -7,11 +7,5 @@
     golang_goroot: true
     golang_gopath: /root/go
 
-  pre_tasks:
-    - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-
   roles:
     - ansible-role-golang

--- a/molecule/force_update/converge.yml
+++ b/molecule/force_update/converge.yml
@@ -9,12 +9,6 @@
       version: 1.15.8
     golang_goroot_versioned: true
 
-  pre_tasks:
-    - name: Update Apt Cache
-      ansible.builtin.apt: "update_cache=yes cache_valid_time={{ 60 * 15 }}"
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-
   roles:
     - ansible-role-golang
 


### PR DESCRIPTION
This PR:

- Remove the apt `update_cache` pre_task from all Molecule plays because all apt module instances are configured to run this when necessary anyways.